### PR TITLE
Take dependencies into account when filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,12 +759,6 @@ tests. The resource may or may not be managed by `withResource`.)
      ]
    ```
 
-Filtering might not behave the way you expect when using dependencies:
-if Test B depends on Test A, remember that either of them may be filtered out
-using the `--pattern` option. Collecting the dependency info happens *after*
-filtering. Therefore, if Test A is filtered out, Test B will run
-unconditionally, and if Test B is filtered out, it simply won't run.
-
 Using patterns to specify dependencies has a few more caveats:
 
 1. Tasty does not currently check whether the pattern in a dependency matches
@@ -788,6 +782,7 @@ Using patterns to specify dependencies has a few more caveats:
    test tree, searching for the next test to execute may also have an
    overhead quadratic in the number of tests.
 
+To avoid these gotchas, consider using `afterTree` or `sequentialTestGroup`.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -691,13 +691,16 @@ Tasty executes tests in parallel to make them finish faster.
 If this parallelism is not desirable, you can declare *dependencies* between
 tests, so that one test will not start until certain other tests finish.
 
-Dependencies are declared using the `after` combinator:
+Dependencies are declared using the `after` or `afterTree` combinator:
 
 * `after AllFinish "pattern" my_tests` will execute the test tree `my_tests` only after all
     tests that match the pattern finish.
 * `after AllSucceed "pattern" my_tests` will execute the test tree `my_tests` only after all
     tests that match the pattern finish **and** only if they all succeed. If at
     least one dependency fails, then `my_tests` will be skipped.
+* `afterTree dependencyType tree1 tree2` will execute all tests in `tree1` first, after which it
+   will execute all tests in `tree2`. Like `after`, `dependencyType` can either be set to `AllFinish`
+   or `AllSucceed`. If you're looking to chain a bunch of tests, use `sequentialTestGroup`.
 
 The relevant types are:
 
@@ -707,6 +710,18 @@ after
   -> String         -- ^ the pattern
   -> TestTree       -- ^ the subtree that depends on other tests
   -> TestTree       -- ^ the subtree annotated with dependency information
+
+afterTree
+  :: DependencyType -- ^ whether to run the tests even if some of the dependencies fail
+  -> TestTree       -- ^ dependencies
+  -> TestTree       -- ^ tests to run after all dependencies have finished
+  -> TestTree
+
+sequentialTestGroup
+  :: String         -- ^ Test group name
+  -> DependencyType -- ^ whether to run the tests even if some of the dependencies fail
+  -> [TestTree]     -- ^ tests to run sequentially
+  -> TestTree
 
 data DependencyType = AllSucceed | AllFinish
 ```
@@ -744,12 +759,14 @@ tests. The resource may or may not be managed by `withResource`.)
      ]
    ```
 
-Here are some caveats to keep in mind regarding dependencies in Tasty:
+Filtering might not behave the way you expect when using dependencies:
+if Test B depends on Test A, remember that either of them may be filtered out
+using the `--pattern` option. Collecting the dependency info happens *after*
+filtering. Therefore, if Test A is filtered out, Test B will run
+unconditionally, and if Test B is filtered out, it simply won't run.
 
-1. If Test B depends on Test A, remember that either of them may be filtered out
-   using the `--pattern` option. Collecting the dependency info happens *after*
-   filtering. Therefore, if Test A is filtered out, Test B will run
-   unconditionally, and if Test B is filtered out, it simply won't run.
+Using patterns to specify dependencies has a few more caveats:
+
 1. Tasty does not currently check whether the pattern in a dependency matches
    anything at all, so make sure your patterns are correct and do not contain
    typos. Fortunately, misspecified dependencies usually lead to test failures

--- a/core-tests/AfterTree.hs
+++ b/core-tests/AfterTree.hs
@@ -1,0 +1,214 @@
+{-# LANGUAGE DeriveGeneric, DeriveFoldable, FlexibleInstances, LambdaCase, NamedFieldPuns #-}
+{-# LANGUAGE TypeApplications #-}
+
+module AfterTree where
+
+import Control.Concurrent
+import Control.Monad (forM_)
+import Data.Coerce (coerce)
+import Data.List (mapAccumL)
+import GHC.Generics (Generic)
+import GHC.IO.Unsafe (unsafePerformIO)
+import System.Random (randomIO)
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.Options
+import Test.Tasty.Runners
+import qualified Test.Tasty.QuickCheck as Q
+
+import Utils (runSMap)
+
+-- | Magic constant determining the number of threads to run with. Should be at
+-- least 2 to trigger chaotic behavior.
+nUM_THREADS :: NumThreads
+nUM_THREADS = NumThreads 3
+
+testAfterTree :: TestTree
+testAfterTree =
+  adjustOption (const nUM_THREADS) $
+
+  testGroup "AfterTree"
+  [ testGroup "tree0"           [toTestTree (GenUniqueLabels True)  (labelTree tree0)]
+  , testGroup "tree1"           [toTestTree (GenUniqueLabels True)  (labelTree tree1)]
+  , testGroup "tree2"           [toTestTree (GenUniqueLabels True)  (labelTree tree2)]
+  , testGroup "tree3"           [toTestTree (GenUniqueLabels True)  (labelTree tree3)]
+  , testGroup "tree4"           [toTestTree (GenUniqueLabels True)  (labelTree tree4)]
+  , testGroup "tree5"           [toTestTree (GenUniqueLabels True)  (labelTree tree5)]
+  , testGroup "tree5_no_unique" [toTestTree (GenUniqueLabels False) (labelTree tree5)]
+
+  , Q.testProperty "prop_tree" unsafeRunTest
+  ]
+
+tree0 :: SimpleTestTree () ()
+tree0 = Test ()
+
+tree1 :: SimpleTestTree () ()
+tree1 = InParallel () [Test (), Test (), Test ()]
+
+tree2 :: SimpleTestTree () ()
+tree2 = Sequentially () (Test ()) (Test ())
+
+tree3 :: SimpleTestTree () ()
+tree3 = Sequentially () tree1 tree2
+
+tree4 :: SimpleTestTree () ()
+tree4 = Sequentially () tree2 tree1
+
+tree5 :: SimpleTestTree () ()
+tree5 = InParallel () [tree0, tree1, tree2, tree3, tree4]
+
+-- | Whether to generate unique labels in 'labelTree'. 'AfterTree' should work
+-- properly, even if there are name collisions in the test tree.
+newtype GenUniqueLabels = GenUniqueLabels Bool
+  deriving Show
+
+instance Q.Arbitrary GenUniqueLabels where
+  arbitrary = coerce (Q.arbitrary @Bool)
+  shrink = coerce (Q.shrink @Bool)
+
+-- | Range composed from a lower bound up to and including an upper bound
+type Range a = (a, a)
+
+-- | Is given element in range?
+inRange :: Ord a => Range a -> a -> Bool
+inRange (lower, upper) a = a >= lower && a <= upper
+
+-- | Extract a range from any constructor of 'SimpleTestTree'
+getRange :: SimpleTestTree (Range Word) Word -> Range Word
+getRange tree = case tree of
+  InParallel r _ -> r
+  Sequentially r _ _ -> r
+  Test n -> (n, n)
+
+-- | Simplified version of Tasty's TestTree. Used to generate test cases for
+-- 'AfterTree'.
+data SimpleTestTree n l
+  = InParallel n [SimpleTestTree n l]
+  | Sequentially n (SimpleTestTree n l) (SimpleTestTree n l)
+  | Test l
+  deriving (Show, Eq, Ord, Generic, Foldable)
+
+-- | Attach a unique label to each test. Trees are labeled left-to-right in
+-- ascending order. Each node contains a range, which indicates what words
+-- are stored in the leafs corresponding to that node.
+labelTree :: SimpleTestTree () () -> SimpleTestTree (Range Word) Word
+labelTree = snd . go 0
+ where
+  go n0 = \case
+    Test () -> (n0 + 1, Test n0)
+
+    InParallel () ts0 ->
+      let
+        (n1, ts1) = mapAccumL go n0 ts0
+      in
+        (n1, InParallel (n0, n1-1) ts1)
+
+    Sequentially () t0 t1 ->
+      let
+        (n1, t0') = go n0 t0
+        (n2, t1') = go n1 t1
+      in
+        (n2, Sequentially (n0, n2-1) t0' t1')
+
+-- | Generates a 'SimpleTestTree' with arbitrary branches with 'InParallel' and
+-- 'Sequentially'. The generated test tree is at most 5 levels deep, and each
+-- level generates smaller and smaller 'InParallel' lists. This prevents trees
+-- from growing incredibly large.
+instance Q.Arbitrary (SimpleTestTree () ()) where
+  arbitrary = Q.sized (go . min 5)
+   where
+    go n = do
+      if n <= 0 then
+        pure (Test ())
+      else
+        Q.frequency
+          [ (1, InParallel () <$> (take n <$> Q.listOf (go (n-1))))
+          , (1, Sequentially () <$> go (n-1) <*> go (n-1))
+          , (1, pure (Test ())) 
+          ]
+
+  shrink = Q.genericShrink
+
+-- | Run a simple test tree (see 'toTestTree' for more information) in a separate
+-- Tasty "session" to not pollute the test report. Marked unsafe as it uses
+-- 'unsafePerformIO' - which makes it possible to run with 'Q.testProperty'.
+unsafeRunTest :: GenUniqueLabels -> SimpleTestTree () () -> ()
+unsafeRunTest genUniqueLabels testTree0 = unsafePerformIO $ do
+  results <- launchTestTree (singleOption nUM_THREADS) testTree1 $ \smap -> do
+    res <- runSMap smap
+    pure (const (pure res))
+
+  forM_ results $ \Result{resultOutcome}->
+    case resultOutcome of
+      Success -> pure ()
+      Failure reason -> assertFailure (show reason)
+ where
+  testTree1 :: TestTree
+  testTree1 = toTestTree genUniqueLabels (labelTree testTree0)
+{-# NOINLINE unsafeRunTest #-}
+
+-- | Constructs a 'TestTree' from a 'SimpleTestTree'. 'testGroup' is used to
+-- construct parallel test cases in 'InParallel'. Sequential test cases are
+-- constructed using 'afterTree' in 'Sequentially'. A 'Test' prepends its
+-- label to a list shared between all tests. Finally, 'checkResult' is used
+-- to check whether the labels were prepended in a sensible order.
+toTestTree :: GenUniqueLabels -> SimpleTestTree (Range Word) Word -> TestTree
+toTestTree (GenUniqueLabels genUniqueLabels) tree =
+  withResource (newMVar []) (const (pure ())) $ \mVar ->
+    afterTree AllSucceed (go tree mVar) (checkResult tree mVar)
+ where
+  go :: SimpleTestTree n Word -> IO (MVar [Word]) -> TestTree
+  go tree mVarIO = case tree of
+    InParallel _ stts ->
+      testGroup "Par" (map (`go` mVarIO) stts)
+
+    Sequentially _ t0 t1 ->
+      afterTree AllSucceed (go t0 mVarIO) (go t1 mVarIO)
+
+    Test n -> do
+      -- Caller might opt to not generate unique labels for each test: AfterTree
+      -- should still function properly in face of name collisions.
+      let label = if genUniqueLabels then "T" ++ show n else "T"
+
+      testCase label $ do
+        -- Induce a (very) small delay to make sure tests finish in a chaotic
+        -- order when executed in parallel.
+        smallDelay <- (`mod` 100) <$> randomIO
+        threadDelay smallDelay
+
+        mVar <- mVarIO
+        modifyMVar_ mVar (\ns -> pure $ n:ns)
+
+-- | Checks whether all test cases wrote their labels in the order imposed by
+-- the given 'SimpleTestTree'. The invariant that should hold is: given any
+-- @Sequentially t1 t2@, all labels associated with @t1@ should appear _later_
+-- in the word-list than all labels associated with @t2@.
+checkResult :: SimpleTestTree (Range Word) Word -> IO (MVar [Word]) -> TestTree
+checkResult fullTree resultM =
+  testCase "checkResult" (resultM >>= takeMVar >>= go fullTree)
+ where
+  go :: SimpleTestTree (Range Word) Word -> [Word] -> Assertion
+  go tree result0 = case tree of
+    InParallel _ ts ->
+      mapM_ (`go` result0) ts
+
+    Sequentially r t0 t1 -> do
+      let
+        -- Parallel execution might "pollute" the result list with tests that are
+        -- neither in 'r0' nor in 'r1'.
+        result1 = filter (inRange r) result0
+
+        -- Note that 'result' is preprended during test execution, so tests that
+        -- ran last appear first. Hence, we split the list on `r1`, not `r0`.
+        (res1, res0) = span (inRange (getRange t1)) result1
+
+      -- Recurse on both branches; if any element is missing or misplaced, the 'Test'
+      -- branch will make sure the test fails.
+      go t0 res0
+      go t1 res1
+
+    Test n ->
+      assertBool
+        (show n ++ " should be present in " ++ show result0)
+        (n `elem` result0)

--- a/core-tests/Dependencies.hs
+++ b/core-tests/Dependencies.hs
@@ -18,6 +18,7 @@ testDependencies :: TestTree
 testDependencies = testGroup "Dependencies" $
   generalDependencyTests ++
   [circDepShow] ++
+  generalExactDependencyTests ++
   circDepTests ++
   [resourceDependenciesTest]
 
@@ -40,6 +41,16 @@ circDepShow = testCase "show DependencyLoop" $
       , "- a.foo, b, a.foo"
       , "- c, d.bar, c"
       ])
+
+-- this is a dummy tree we use for testing
+testExactTree :: DependencyType -> Bool -> TestTree
+testExactTree deptype succeed =
+  testGroup "exact dependency test"
+    [ testCase "Two" $ threadDelay 1e6
+    , afterTree deptype
+        (testCase "Three" $ threadDelay 1e6 >> assertBool "fail" succeed)
+        (testCase "One" $ threadDelay 1e6)
+    ]
 
 -- an example of a tree with circular dependencies
 circDepTree1 :: TestTree
@@ -83,6 +94,59 @@ generalDependencyTests = do
   return $ testCase (printf "%-5s %s" (show succeed) (show deptype)) $ do
     launchTestTree (singleOption $ NumThreads 2) (testTree deptype succeed) $ \smap -> do
       let all_tests@[one, two, three] = IntMap.elems smap
+      -- at first, no tests have finished yet
+      threadDelay 2e5
+      forM_ all_tests $ \tv -> do
+        st <- atomically $ readTVar tv
+        assertBool (show st) $
+          case st of
+            Done {} -> False
+            _ -> True
+
+      -- after ≈ 1 second, the second and third tests will have finished;
+      -- the first will have not unless it is skipped because the first one
+      -- failed
+      threadDelay 11e5
+      st <- atomically $ readTVar three
+      assertBool (show st) $
+        case st of
+          Done r -> resultSuccessful r == succeed
+          _ -> False
+      st <- atomically $ readTVar two
+      assertBool (show st) $
+        case st of
+          Done r -> resultSuccessful r == True
+          _ -> False
+      st <- atomically $ readTVar one
+      assertBool (show st) $
+        case st of
+          Done _ | succeed || deptype == AllFinish -> False
+          _ -> True
+
+      -- after ≈ 2 seconds, the third test will have finished as well
+      threadDelay 1e6
+      st <- atomically $ readTVar one
+      assertBool (show st) $
+        case st of
+          Done r
+            | succeed || deptype == AllFinish -> resultSuccessful r
+            | otherwise ->
+                case resultOutcome r of
+                  Failure TestDepFailed -> True
+                  _ -> False
+          _ -> False
+
+      return $ const $ return ()
+
+-- | Check the semantics of exact dependencies. This is the same as
+-- 'generalDependencyTests', but using 'afterTree'.
+generalExactDependencyTests :: [TestTree]
+generalExactDependencyTests = do
+  succeed <- [True, False]
+  deptype <- [AllSucceed, AllFinish]
+  return $ testCase (printf "exact %-5s %s" (show succeed) (show deptype)) $ do
+    launchTestTree (singleOption $ NumThreads 2) (testExactTree deptype succeed) $ \smap -> do
+      let all_tests@[two, three, one] = IntMap.elems smap
       -- at first, no tests have finished yet
       threadDelay 2e5
       forM_ all_tests $ \tv -> do

--- a/core-tests/Trie.hs
+++ b/core-tests/Trie.hs
@@ -1,0 +1,50 @@
+module Trie where
+
+import qualified Data.Sequence as Seq
+import Data.Sequence (Seq)
+
+import Data.Bifunctor (second)
+import qualified Data.Map as Map
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import qualified Test.Tasty.Patterns.Trie as Trie
+
+-- | A naively constructed 'Trie' through 'Map' should contain the same values
+-- as a 'Trie' constructed from the same list.
+prop_match :: [(Seq Char, Int)] -> Property
+prop_match trieList = expected === actual
+ where
+  expected = map (second Just) (Map.assocs (Map.fromList trieList))
+  actual = map (\(k, _) -> (k, fst (Trie.match trie k))) expected
+  trie = Trie.fromList trieList
+
+-- | A naively constructed 'Trie' through 'Map' should match the same prefixes
+-- as a 'Trie' constructed from the same list. Note that the ad-hoc 'Map'
+-- implementation does the same as 'Trie', but with quadratic complexity.
+prop_matchPrefix :: [(Seq Char, Int)] -> Property
+prop_matchPrefix trieList0 = expected === actual
+ where
+  actual =
+    flip concatMap trieList1 $ \(k, _) ->
+      flip concatMap (prefixes k) $ \prefix ->
+        Trie.matchPrefix trie prefix
+
+  expected =
+    flip concatMap trieList1 $ \(k, _) ->
+      flip concatMap (prefixes k) $ \prefix ->
+        [(path, v) | (path, v) <- trieList1, isPrefix prefix path]
+
+  trie = Trie.fromList trieList0
+  trieList1 = Map.assocs (Map.fromList trieList0)
+  prefixes k = map (`Seq.take` k) [0..Seq.length k]
+
+  isPrefix prefix path
+    | Seq.length prefix > Seq.length path = False
+    | otherwise = prefix == Seq.take (Seq.length prefix) path
+
+testTrie :: TestTree
+testTrie = testGroup "Trie"
+  [ testProperty "prop_match" prop_match
+  , testProperty "prop_matchPrefix" prop_matchPrefix
+  ]

--- a/core-tests/core-tests.cabal
+++ b/core-tests/core-tests.cabal
@@ -17,10 +17,10 @@ cabal-version:       >=1.10
 
 executable tasty-core-tests
   main-is:             test.hs
-  other-modules:       Resources, Timeouts, Utils, AWK, Dependencies
+  other-modules:       Resources, Timeouts, Utils, AWK, AfterTree, Dependencies, Trie
   -- other-extensions:
   build-depends:       base >= 4.9 && <= 5, tasty, tasty-hunit, tasty-golden, tasty-quickcheck, containers, stm, mtl,
-                       filepath, bytestring, optparse-applicative
+                       filepath, bytestring, optparse-applicative, random
   -- hs-source-dirs:
   default-language:    Haskell2010
   default-extensions:  CPP, NumDecimals

--- a/core-tests/test.hs
+++ b/core-tests/test.hs
@@ -10,7 +10,9 @@ import Options.Applicative
 import Resources
 import Timeouts
 import Dependencies
+import AfterTree
 import AWK
+import Trie
 
 main :: IO ()
 main = do
@@ -23,6 +25,8 @@ mainGroup = do
     [ testResources
     , testTimeouts
     , testDependencies
+    , testAfterTree
+    , testTrie
     , patternTests
     , awkTests_
     , optionMessagesTests
@@ -66,7 +70,7 @@ getTestNames :: OptionSet -> TestTree -> [String]
 getTestNames =
   foldTestTree
     trivialFold
-      { foldSingle = \_ name _ -> [name]
+      { foldSingle = \_ _ name _ -> [name]
       , foldGroup = \_opts n l -> map ((n ++ ".") ++) l
       }
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased
 _YYYY-MM-DD_
 
 - Dependency loop error now lists all test cases that formed a cycle
+- Dependencies can now be defined pattern-free with `afterTree` and `sequentialTestGroup`
 
 Version 1.4.2.3
 ---------------

--- a/core/Test/Tasty.hs
+++ b/core/Test/Tasty.hs
@@ -59,6 +59,8 @@ module Test.Tasty
   , DependencyType(..)
   , after
   , after_
+  , afterTree
+  , sequentialTestGroup
   )
   where
 

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -59,6 +59,7 @@ import Data.Typeable
 import Options.Applicative hiding (action, str, Success, Failure)
 import System.IO
 import System.Console.ANSI
+import Test.Tasty.Patterns.Eval (ExactPath)
 #if !MIN_VERSION_base(4,11,0)
 import Data.Foldable (foldMap)
 #endif
@@ -119,8 +120,8 @@ buildTestOutput opts tree =
 
     runSingleTest
       :: (IsTest t, ?colors :: Bool)
-      => OptionSet -> TestName -> t -> Ap (Reader Level) TestOutput
-    runSingleTest _opts name _test = Ap $ do
+      => OptionSet -> ExactPath -> TestName -> t -> Ap (Reader Level) TestOutput
+    runSingleTest _opts _path name _test = Ap $ do
       level <- ask
 
       let
@@ -660,7 +661,7 @@ computeAlignment opts =
   fromMonoid .
   foldTestTree
     trivialFold
-      { foldSingle = \_ name _ level -> Maximum (stringWidth name + level)
+      { foldSingle = \_ _ name _ level -> Maximum (stringWidth name + level)
       , foldGroup = \_opts _ m -> m . (+ indentSize)
       }
     opts

--- a/core/Test/Tasty/Ingredients/ListTests.hs
+++ b/core/Test/Tasty/Ingredients/ListTests.hs
@@ -30,7 +30,7 @@ testsNames :: OptionSet -> TestTree -> [TestName]
 testsNames {- opts -} {- tree -} =
   foldTestTree
     trivialFold
-      { foldSingle = \_opts name _test -> [name]
+      { foldSingle = \_opts _path name _test -> [name]
       , foldGroup = \_opts groupName names -> map ((groupName ++ ".") ++) names
       }
 

--- a/core/Test/Tasty/Patterns/Eval.hs
+++ b/core/Test/Tasty/Patterns/Eval.hs
@@ -1,5 +1,14 @@
-{-# LANGUAGE RankNTypes, ViewPatterns #-}
-module Test.Tasty.Patterns.Eval (Path, eval, withFields, asB) where
+{-# LANGUAGE RankNTypes, ViewPatterns, LambdaCase #-}
+module Test.Tasty.Patterns.Eval
+  ( ExactPath
+  , ExactPathComponent(..)
+  , LeftOrRight(L, R)
+  , Path
+  , exactPathToPath
+  , eval
+  , withFields
+  , asB
+  ) where
 
 import Prelude hiding (Ordering(..))
 import Control.Monad ((<=<))
@@ -16,7 +25,34 @@ import Control.Applicative
 import Data.Traversable
 #endif
 
+data LeftOrRight = L | R
+  deriving (Show, Eq, Ord)
+
+data ExactPathComponent
+  = EpcSingleTest String
+  | EpcTestGroup String Int
+  | EpcPlusTestOptions
+  | EpcWithResource
+  | EpcAskOptions
+  | EpcAfter
+  | EpcAfterTree LeftOrRight
+  deriving (Show, Eq, Ord)
+
+type ExactPath = Seq.Seq ExactPathComponent
 type Path = Seq.Seq String
+
+exactPathToPath :: ExactPath -> Path
+exactPathToPath = Seq.fromList . catMaybes . toList . fmap toName
+ where
+  toName :: ExactPathComponent -> Maybe String
+  toName = \case
+    EpcSingleTest s -> Just s
+    EpcTestGroup s _ -> Just s
+    EpcPlusTestOptions -> Nothing
+    EpcWithResource -> Nothing
+    EpcAskOptions -> Nothing
+    EpcAfter -> Nothing
+    EpcAfterTree _ -> Nothing
 
 data Value
   = VN !Int

--- a/core/Test/Tasty/Patterns/Trie.hs
+++ b/core/Test/Tasty/Patterns/Trie.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- |
+-- A barebones implementation of a prefix tree. Within Tasty it is used to efficiently
+-- match dependencies constructed with 'AfterTree'.
+--
+module Test.Tasty.Patterns.Trie where
+
+import Prelude hiding (lookup)
+
+import Data.List (foldl')
+import Data.Maybe (fromMaybe)
+import Data.Sequence (Seq, ViewL(EmptyL, (:<)), viewl, (|>))
+
+import Data.Map (Map)
+import qualified Data.Map as Map
+
+
+#if !MIN_VERSION_base(4,11,0)
+import Data.Monoid ((<>))
+#endif
+
+-- | A 'Trie' (also called a prefix tree, or digital tree) is an n-ary search
+-- tree. It allows efficient retrieval of values matching some prefix.
+data Trie k v = Trie
+  { value :: !(Maybe v)
+  , children :: !(Map k (Trie k v))
+  }
+
+-- | 'Trie' without any values.
+empty :: Trie k v
+empty = Trie Nothing Map.empty
+
+-- | Construct a 'Trie' from a list. If a key is found multiple times, only the
+-- last value is inserted.
+fromList :: Ord k => [(Seq k, v)] -> Trie k v
+fromList = foldl' (uncurry . insert) empty
+
+-- | Return all keys and values in the 'Trie'
+toList :: Trie k v -> [(Seq k, v)]
+toList = go mempty
+ where
+  go :: Seq k -> Trie k v -> [(Seq k, v)]
+  go key (Trie (Just v) children) =
+    (key, v) : go key (Trie Nothing children)
+
+  go key (Trie Nothing children) =
+    flip concatMap (Map.assocs children) $ \(p, subTrie) ->
+      go (key |> p) subTrie
+
+-- | Lookup a key in a 'Trie'. Returns the exact match, and all of its children.
+match :: Ord k => Trie k v -> Seq k -> (Maybe v, [(Seq k, v)])
+match t prefix0 = go t prefix0
+ where
+  go Trie{value, children} prefix1 =
+    case viewl prefix1 of
+      EmptyL ->
+        let
+          childrenNoPrefix = toList Trie{value=Nothing, children=children}
+          prependPrefix (k, v) = (prefix0 <> k, v)
+        in
+          (value, map prependPrefix childrenNoPrefix)
+
+      k :< ks ->
+        case Map.lookup k children of
+          Nothing -> (Nothing, [])
+          Just subTrie -> go subTrie ks
+
+-- | Lookup a key in a 'Trie'. Returns the exact match, and all of its children.
+matchPrefix :: Ord k => Trie k v -> Seq k -> [(Seq k, v)]
+matchPrefix trie prefix =
+  case match trie prefix of
+    (Nothing, kvs) -> kvs
+    (Just v, kvs) -> (prefix, v) : kvs
+
+-- | Lookup an key in a 'Trie'. Returns 'Nothing' if no such value exists.
+lookup :: Ord k => Trie k v -> Seq k -> Maybe v
+lookup trie key = fst (match trie key)
+
+-- | Inserts a value into a 'Trie'. If a value already exists for the given key,
+-- it is overwritten.
+insert :: Ord k => Trie k v -> Seq k -> v -> Trie k v
+insert trie@Trie{children} key v =
+  case viewl key of
+    EmptyL ->
+      Trie (Just v) children
+
+    k :< ks ->
+      let
+        subTrie0 = fromMaybe empty (Map.lookup k children)
+        subTrie1 = insert subTrie0 ks v
+      in
+        trie{children=Map.insert k subTrie1 children}

--- a/core/Test/Tasty/Run.hs
+++ b/core/Test/Tasty/Run.hs
@@ -1,7 +1,6 @@
 -- | Running tests
 {-# LANGUAGE ScopedTypeVariables, ExistentialQuantification, RankNTypes,
-             FlexibleContexts, BangPatterns, CPP, DeriveDataTypeable,
-             TupleSections, NamedFieldPuns, LambdaCase #-}
+             FlexibleContexts, CPP, TupleSections #-}
 module Test.Tasty.Run
   ( Status(..)
   , StatusMap
@@ -13,14 +12,11 @@ import qualified Data.IntMap as IntMap
 import qualified Data.Sequence as Seq
 import qualified Data.Foldable as F
 import Data.Maybe
-import Data.List (intercalate)
-import Data.Graph (SCC(..), stronglyConnComp)
-import Data.Typeable
-import Control.Monad (forever, guard, join, liftM)
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict ((!))
+import Control.Monad (forever, join, liftM)
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.Reader (ReaderT(..), local, ask)
-import Control.Monad.Trans.Writer (WriterT(..), execWriterT, mapWriterT, tell)
+import Control.Monad.Trans.Writer (WriterT(..), execWriterT, tell)
 import Control.Concurrent
 import Control.Concurrent.STM
 import Control.Concurrent.Timeout (timeout)
@@ -34,16 +30,12 @@ import Prelude  -- Silence AMP and FTP import warnings
 
 import Test.Tasty.Core
 import Test.Tasty.Parallel
-import Test.Tasty.Patterns
-import Test.Tasty.Patterns.Types
 import Test.Tasty.Patterns.Eval
-import qualified Test.Tasty.Patterns.Trie as Trie
 import Test.Tasty.Options
 import Test.Tasty.Options.Core
 import Test.Tasty.Runners.Reducers
 import Test.Tasty.Runners.Utils (timed, forceElements)
 import Test.Tasty.Providers.ConsoleFormat (noResultDetails)
-import qualified Data.Foldable as Seq
 
 -- | Current status of a test
 data Status
@@ -213,50 +205,8 @@ executeTest action statusVar timeoutOpt inits fins = mask $ \restore -> do
 
 type InitFinPair = (Seq.Seq Initializer, Seq.Seq Finalizer)
 
--- | Specifies how to calculate a dependency
-data DependencySpec
-  = ExactDep ExactPath
-  -- ^ All tests mathing this 'ExactPath' plus its children should be considered
-  -- dependencies.
-  | PatternDep Expr
-  -- ^ All tests matching this 'Expr' should be considered dependencies
-  deriving (Show, Eq)
-
--- | Dependency of a test. Either it points to an exact path it depends on, or
--- contains a pattern that should be tested against all tests in a 'TestTree'.
-data Dependency = Dependency
-  { dpType :: DependencyType
-  , dpSpec :: DependencySpec
-  }
-  deriving (Show, Eq)
-
--- | Dependencies of a test
-type Deps = [Dependency]
-
 -- | Traversal type used in 'createTestActions'
-type Tr = Traversal
-        (WriterT ([(InitFinPair -> IO (), (TVar Status, ExactPath, Deps))], Seq.Seq Finalizer)
-        (ReaderT Deps IO))
-
--- | Exceptions related to dependencies between tests.
-data DependencyException
-  = DependencyLoop [[Path]]
-    -- ^ Test dependencies form cycles. In other words, test A cannot start
-    -- until test B finishes, and test B cannot start until test
-    -- A finishes. Field lists detected cycles.
-  deriving (Typeable)
-
-instance Show DependencyException where
-  show (DependencyLoop css) = "Test dependencies have cycles:\n" ++ showCycles css
-    where
-      showCycles = intercalate "\n" . map showCycle
-      showPath = intercalate "." . F.toList
-
-      -- For clarity in the error message, the first element is repeated at the end
-      showCycle []     = "- <empty cycle>"
-      showCycle (x:xs) = "- " ++ intercalate ", " (map showPath (x:xs ++ [x]))
-
-instance Exception DependencyException
+type Tr = Traversal (WriterT ([(InitFinPair -> IO (), (TVar Status, ExactPath))], Seq.Seq Finalizer) IO)
 
 -- | Turn a test tree into a list of actions to run tests coupled with
 -- variables to watch them.
@@ -266,48 +216,30 @@ createTestActions
   -> IO ([(Action, TVar Status)], Seq.Seq Finalizer)
 createTestActions opts0 tree = do
   let
-    traversal :: Tr
-    traversal =
-      foldTestTree
-        (trivialFold :: TreeFold Tr)
-          { foldSingle = runSingleTest
-          , foldResource = addInitAndRelease
-          , foldGroup = \_opts _name (Traversal a) ->
-              Traversal a
-          , foldAfter = \_opts deptype pat (Traversal a) ->
-              let dep = Dependency{dpType=deptype, dpSpec=PatternDep pat} in
-              Traversal $ mapWriterT (local (dep:)) a
-          , foldAfterTree = \_opts deptype pathLeft (Traversal a) ->
-              let dep = Dependency{dpType=deptype, dpSpec=ExactDep pathLeft} in
-              Traversal $ mapWriterT (local (dep:)) a
-          }
-        opts0 tree
-  (tests, fins) <- unwrap (mempty :: Deps) traversal
+    folder = trivialFold{foldSingle = runSingleTest, foldResource = addInitAndRelease}
+    (traversal, depTree) = foldTestTreeWithDeps folder opts0 tree
+  (tests, fins) <- unwrap traversal
 
   let
-    mb_tests :: Either [[ExactPath]] [(Action, TVar Status)]
-    mb_tests = resolveDeps $ map
-      (\(act, testInfo) ->
-        (act (Seq.empty, Seq.empty), testInfo))
-      tests
-  case mb_tests of
-    Right tests' -> return (tests', fins)
-    Left cycles -> throwIO (DependencyLoop (map exactPathToPath <$> cycles))
+    tests' :: [(Action, TVar Status)]
+    tests' = resolveDeps depTree $ flip map tests $ \(act, testInfo) ->
+        (act (Seq.empty, Seq.empty), testInfo)
+
+  return (tests', fins)
 
   where
     runSingleTest :: IsTest t => OptionSet -> ExactPath -> TestName -> t -> Tr
     runSingleTest opts path _name test = Traversal $ do
       statusVar <- liftIO $ atomically $ newTVar NotStarted
-      deps <- lift ask
       let
         act (inits, fins) =
           executeTest (run opts test) statusVar (lookupOption opts) inits fins
-      tell ([(act, (statusVar, path, deps))], mempty)
+      tell ([(act, (statusVar, path))], mempty)
 
     addInitAndRelease :: OptionSet -> ResourceSpec a -> (IO a -> Tr) -> Tr
-    addInitAndRelease _opts (ResourceSpec doInit doRelease) a = wrap $ \deps -> do
+    addInitAndRelease _opts (ResourceSpec doInit doRelease) a = wrap $ do
       initVar <- atomically $ newTVar NotCreated
-      (tests, fins) <- unwrap deps $ a (getResource initVar)
+      (tests, fins) <- unwrap $ a (getResource initVar)
       let ntests = length tests
       finishVar <- atomically $ newTVar ntests
       let
@@ -317,50 +249,29 @@ createTestActions opts0 tree = do
       return (tests', fins Seq.|> fin)
 
     wrap
-      :: (Deps ->
-          IO ([(InitFinPair -> IO (), (TVar Status, ExactPath, Deps))], Seq.Seq Finalizer))
+      :: IO ([(InitFinPair -> IO (), (TVar Status, ExactPath))], Seq.Seq Finalizer)
       -> Tr
-    wrap = Traversal . WriterT . fmap ((),) . ReaderT
+    wrap = Traversal . WriterT . fmap ((),)
 
     unwrap
-      :: Deps
-      -> Tr
-      -> IO ([(InitFinPair -> IO (), (TVar Status, ExactPath, Deps))], Seq.Seq Finalizer)
-    unwrap deps = flip runReaderT deps . execWriterT . getTraversal
+      :: Tr
+      -> IO ([(InitFinPair -> IO (), (TVar Status, ExactPath))], Seq.Seq Finalizer)
+    unwrap = execWriterT . getTraversal
 
 -- | Take care of the dependencies.
 --
 -- Return 'Left' if there is a dependency cycle, containing the detected cycles.
 resolveDeps
-  :: [(IO (), (TVar Status, ExactPath, Deps))]
-  -> Either [[ExactPath]] [(Action, TVar Status)]
-resolveDeps tests = checkCycles $ do
-  (run_test, (statusVar, path0, deps)) <- tests
+  :: DependencyTree
+  -> [(IO (), (TVar Status, ExactPath))]
+  -> [(Action, TVar Status)]
+resolveDeps depTree tests = do
+  (run_test, (statusVar, path0)) <- tests
   let
     deps' :: [(DependencyType, TVar Status, ExactPath)]
     deps' = do
-      Dependency{dpType, dpSpec} <- deps
-
-      case dpSpec of
-        ExactDep path -> do
-          (depPath, statusVar1) <- Trie.matchPrefix testTrie path
-          -- Filter any dependencies that are part of the _left_ side of an
-          -- 'AfterTree'. All tests in the _right_ tree depend on them to
-          -- finish anyway, so no need to wait pollute the dependency list
-          -- with them.
-          let subDepPath = Seq.drop (length depPath) depPath
-          guard $ Seq.notElem (EpcAfterTree L) subDepPath
-          return (dpType, statusVar1, depPath)
-
-        -- Note: Duplicate dependencies may arise if the same test name matches
-        -- multiple patterns. It's not clear that removing them is worth the
-        -- trouble; might consider this in the future.
-        PatternDep depexpr -> do
-          -- Consider each test in the whole test tree, and filter the ones
-          -- that match 'depexpr'.
-          (_, (statusVar1, path, _)) <- tests
-          guard $ exprMatches depexpr (exactPathToPath path)
-          return (dpType, statusVar1, path)
+      (depType, depPath) <- fromMaybe [] (Map.lookup path0 depTree)
+      pure (depType, statVarMap ! depPath, depPath)
 
     getStatus :: STM ActionStatus
     getStatus = foldr
@@ -375,7 +286,6 @@ resolveDeps tests = checkCycles $ do
       (return ActionReady)
       deps'
   let
-    dep_paths = map (\(_, _, path) -> path) deps'
     action = Action
       { actionStatus = getStatus
       , actionRun = run_test
@@ -388,24 +298,10 @@ resolveDeps tests = checkCycles $ do
           , resultDetailsPrinter = noResultDetails
           }
       }
-  return ((action, statusVar), (path0, dep_paths))
+
+  return (action, statusVar)
  where
-  testTrie = Trie.fromList [(path, statVar) | (_io, (statVar, path, _deps)) <- tests]
-
-checkCycles :: Ord b => [(a, (b, [b]))] -> Either [[b]] [a]
-checkCycles tests = do
-  let
-    result = fst <$> tests
-    graph = [ (v, v, vs) | (v, vs) <- snd <$> tests ]
-    sccs = stronglyConnComp graph
-    cycles =
-      flip mapMaybe sccs $ \case
-        AcyclicSCC{} -> Nothing
-        CyclicSCC vs -> Just vs
-
-  case cycles of
-    [] -> Right result
-    _  -> Left cycles
+  statVarMap = Map.fromList [(path, statVar) | (_io, (statVar, path)) <- tests]
 
 -- | Used to create the IO action which is passed in a WithResource node
 getResource :: TVar (Resource r) -> IO r

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -48,6 +48,7 @@ library
     Test.Tasty.Patterns.Parser
     Test.Tasty.Patterns.Printer
     Test.Tasty.Patterns.Eval
+    Test.Tasty.Patterns.Trie
   other-modules:
     Control.Concurrent.Async
     Test.Tasty.Parallel,

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -68,6 +68,7 @@ library
     base                 >= 4.9 && < 5,
     stm                  >= 2.3,
     containers,
+    dlist                >= 1.0 && < 1.1,
     transformers         >= 0.5,
     tagged               >= 0.5,
     optparse-applicative >= 0.14,


### PR DESCRIPTION
Fixes the following caveat mentioned in Tasty's README:
    
>  If Test B depends on Test A, remember that either of them may be filtered
>  out using the --pattern option. Collecting the dependency info happens
>  after filtering. Therefore, if Test A is filtered out, Test B will run
>  unconditionally, and if Test B is filtered out, it simply won't run.